### PR TITLE
Add asp.net 6 based reverse proxy in front of webserver

### DIFF
--- a/Duplicati.Library.RestAPI/WebServer/Server.cs
+++ b/Duplicati.Library.RestAPI/WebServer/Server.cs
@@ -39,7 +39,7 @@ namespace Duplicati.Server.WebServer
         /// <summary>
         /// The default listening port
         /// </summary>
-        public const int DEFAULT_OPTION_PORT = 8200;
+        public const int DEFAULT_OPTION_PORT = 8300;
 
         /// <summary>
         /// Option for setting the webservice SSL certificate

--- a/Duplicati/Server/Duplicati.Server.csproj
+++ b/Duplicati/Server/Duplicati.Server.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\WebserverWebApi\Duplicati.WebserverWebApi.csproj" />
     <ProjectReference Include="..\..\Duplicati.Library.RestAPI\Duplicati.Library.RestAPI.csproj" />
     <ProjectReference Include="..\CommandLine\BackendTester\Duplicati.CommandLine.BackendTester.csproj">
     </ProjectReference>

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using Duplicati.Library.Common;
 using Duplicati.Library.Common.IO;
 using Duplicati.Library.RestAPI;
-using Duplicati.WebserverCore;
+using Duplicati.WebserverWebApi;
 
 namespace Duplicati.Server
 {
@@ -103,7 +103,7 @@ namespace Duplicati.Server
         /// <summary>
         /// Callback to shutdown the modern webserver
         /// </summary>
-        private static Action ShutdownModernWebserver;
+        private static Action ShutdownModernWebserver = () => {};
 
         /// <summary>
         /// The update poll thread.
@@ -347,8 +347,8 @@ namespace Duplicati.Server
             ServerPortChanged |= WebServer.Port != DataConnection.ApplicationSettings.LastWebserverPort;
             DataConnection.ApplicationSettings.LastWebserverPort = WebServer.Port;
 
-            var server = new DuplicatiWebserver();
-            ShutdownModernWebserver = server.Foo();
+            var server = new MyWebServer();
+            ShutdownModernWebserver = server.Start(8200);
         }
 
         private static void SetWorkerThread()

--- a/Duplicati/WebserverWebApi/Controllers/Acknowledgements.cs
+++ b/Duplicati/WebserverWebApi/Controllers/Acknowledgements.cs
@@ -1,21 +1,79 @@
 using Microsoft.AspNetCore.Mvc;
+using Duplicati.WebserverWebApi.Models;
+using System.Reflection;
 
 namespace Duplicati.WebserverWebApi.Controllers;
 
+/// <summary>
+/// Acknowledgements Controller
+/// Provides the REST endpoint /acknowledgements which is called from the ui
+/// to retrieve the acknowledgements text that is to be displayed on the About section 
+/// </summary>
 [ApiController]
-[Route("api/v1/[controller]")]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 public class AcknowledgementsController : ControllerBase
 {
+    /// <summary>
+    /// Filename of the text file that contains the acknowledgements
+    /// </summary>
+    private const string AcknowledgementsFilename = "acknowledgements.txt";
+
+    /// <summary>
+    /// Logger
+    /// </summary>    
     private readonly ILogger<AcknowledgementsController> _logger;
 
+    /// <summary>
+    /// C'tor to create an instance of the AcknowledgementsController
+    /// </summary>
     public AcknowledgementsController(ILogger<AcknowledgementsController> logger)
     {
         _logger = logger;
     }
 
+    /// <summary>
+    /// GET api/v1/acknowledgements
+    /// Reads acknowledgements from file and returns them
+    /// </summary>    
     [HttpGet]
-    public string Get()
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public ActionResult<AcknowledgementsResponse> Get()
     {
-        return "{\"Status\": \"OK\", \"Acknowledgements\": \"This sentence is served from the new asp.net core 6 webapi webserver while the remaining page comes from the existing implementation\"}";
+        // var acknowledgements = string.Empty;
+
+        // var filePath = Path.Join(
+        //     Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+        //     AcknowledgementsFilename);
+
+        // try 
+        // {
+        //     acknowledgements = System.IO.File.ReadAllText(filePath);
+        // } 
+        // catch (Exception e)
+        // {
+        //     _logger.LogError(
+        //         e,
+        //         "Failed reading {0} from {1} ",
+        //         AcknowledgementsFilename,
+        //         filePath);
+            
+        //     return StatusCode(StatusCodes.Status500InternalServerError);
+        // }
+
+        // var response = new AcknowledgementsResponse {
+        //     Status = "OK",
+        //     Acknowledgements = acknowledgements
+        // };
+
+        // return Ok(response);
+
+        return new AcknowledgementsResponse {
+            Status = "OK",
+            Acknowledgements =
+                "This sentence is served from the new asp.net core 6 webapi webserver while the remaining page comes from the existing implementation"
+        };
     }
 }

--- a/Duplicati/WebserverWebApi/Controllers/Acknowledgements.cs
+++ b/Duplicati/WebserverWebApi/Controllers/Acknowledgements.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Duplicati.WebserverWebApi.Controllers;
+
+[ApiController]
+[Route("api/v1/[controller]")]
+public class AcknowledgementsController : ControllerBase
+{
+    private readonly ILogger<AcknowledgementsController> _logger;
+
+    public AcknowledgementsController(ILogger<AcknowledgementsController> logger)
+    {
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public string Get()
+    {
+        return "{\"Status\": \"OK\", \"Acknowledgements\": \"This sentence is served from the new asp.net core 6 webapi webserver while the remaining page comes from the existing implementation\"}";
+    }
+}

--- a/Duplicati/WebserverWebApi/Duplicati.WebserverWebApi.csproj
+++ b/Duplicati/WebserverWebApi/Duplicati.WebserverWebApi.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/Duplicati/WebserverWebApi/Duplicati.WebserverWebApi.csproj
+++ b/Duplicati/WebserverWebApi/Duplicati.WebserverWebApi.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.1.1" />    
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="ReverseProxyConfig.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Duplicati/WebserverWebApi/Models/AcknowledgementsResponse.cs
+++ b/Duplicati/WebserverWebApi/Models/AcknowledgementsResponse.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Duplicati.WebserverWebApi.Models;
+
+
+public class AcknowledgementsResponse 
+{   
+    [JsonPropertyName("Status")]
+    public string Status {get; init;}
+
+    [JsonPropertyName("Acknowledgements")]
+    public string Acknowledgements {get; init;}
+}

--- a/Duplicati/WebserverWebApi/ReverseProxyConfig.json
+++ b/Duplicati/WebserverWebApi/ReverseProxyConfig.json
@@ -1,0 +1,21 @@
+{
+    "ReverseProxy":{
+        "Routes":{
+            "route1": {
+                "ClusterId": "cluster1",
+                "Match": {
+                    "Path": "{**catch-all}"
+                }                
+            }
+        },
+        "Clusters":{
+            "cluster1": {
+                "Destinations": {
+                    "originalImplementation": {
+                        "Address": "http://localhost:8300"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Duplicati/WebserverWebApi/WebserverWebApi.cs
+++ b/Duplicati/WebserverWebApi/WebserverWebApi.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Versioning;
 using System.Reflection;
 
@@ -54,6 +55,12 @@ public class MyWebServer
         builder.WebHost.UseUrls($"http://localhost:{port}");
 
         builder.Services.AddControllers();
+
+        builder.Services.AddApiVersioning(options => {
+            options.ReportApiVersions = true;
+            options.AssumeDefaultVersionWhenUnspecified = true;
+            options.DefaultApiVersion = new ApiVersion(1, 0);
+	    });
 
         var proxyBuilder = builder.Services.AddReverseProxy();
         proxyBuilder.LoadFromConfig(builder.Configuration.GetSection(ConfigSectionName));

--- a/Duplicati/WebserverWebApi/WebserverWebApi.cs
+++ b/Duplicati/WebserverWebApi/WebserverWebApi.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc.Versioning;
+using System.Reflection;
+
+namespace Duplicati.WebserverWebApi;
+
+public class MyWebServer
+{
+    /// <summary>
+    /// Name of the webapplication for the builder
+    /// </summary>
+    private const string ApplicationName = "Duplicati.WebserverWebApi";
+    
+    /// <summary>
+    /// Filename of the configuration file for the reverse proxy
+    /// </summary>
+    private const string ConfigFilename = "ReverseProxyConfig.json";
+    
+    /// <summary>
+    /// Title of the configuration section that holds the proxy configuration options 
+    /// </summary>
+    private const string ConfigSectionName = "ReverseProxy";
+        
+    /// <summary>
+    /// Path of the configuration file for the reverse proxy from 
+    /// (config file should be in the same directory as the executing assembly)
+    /// </summary>
+    private readonly string ConfigPath;
+
+    public MyWebServer()
+    {
+        var assemblyPath = (new System.Uri(Assembly.GetExecutingAssembly().Location)).AbsolutePath;
+        var assemblyDir = Path.GetDirectoryName(assemblyPath);
+        ConfigPath = Path.Join(assemblyDir, ConfigFilename);
+
+    }
+    
+    
+    // Starts the webserver on the given port and returns an action that can be used to stop it
+    public Action Start(int port)
+    {
+        var builder = WebApplication.CreateBuilder(
+            new WebApplicationOptions{
+                ApplicationName=ApplicationName
+            }
+        );
+        builder.Host.ConfigureAppConfiguration((hostingContext,config) => 
+        {
+            config.AddJsonFile(
+                ConfigPath,
+                optional: false,
+                reloadOnChange: false);
+        });
+
+        builder.WebHost.UseUrls($"http://localhost:{port}");
+
+        builder.Services.AddControllers();
+
+        var proxyBuilder = builder.Services.AddReverseProxy();
+        proxyBuilder.LoadFromConfig(builder.Configuration.GetSection(ConfigSectionName));
+        
+        var app = builder.Build();
+        
+        app.UseFileServer();
+
+        app.MapReverseProxy();
+        app.MapControllers();
+        
+        app.Run();
+
+        return () =>  { app.StopAsync(); };
+    }
+}


### PR DESCRIPTION
Setting up a reverse proxy in front of the existing webserver using yarp. 
The proxy is basically an asp.net 6 core webapi project which uses [yarp](https://github.com/microsoft/reverse-proxy) as a reverse proxy while also offering it's own controller and middle-ware based endpoint(s). Currently there is just one controller defined for `api/v1/acknowledgements` to demonstrate the concept. 

The "old" webserver is moved to port 8300, and the reverse proxy is now listening on 8200, forwarding all requests that it can't fulfill itself to the old webserver.  

Currently, only the `api/v1/acknowledgements` endpoint is directly served by the new implementation, providing some dummy test message, while all other requests are served by the existing implementation of the "old" webserver. 

This setup allows to gradually replace one rest endpoint after another. 

This is currently a proof of concept - not yet fully tested for any unexpected side-effects ;-)